### PR TITLE
Scheduling Interval Fix

### DIFF
--- a/scripts/welcome.js
+++ b/scripts/welcome.js
@@ -12,7 +12,7 @@ module.exports = function(robot){
   var WELCOME_MESSAGES = ['Working on anything interesting?', 'Tell us about yourself!', 'Anything we can help you with?']
 
   /** check the welcome queue every 2 minutes */
-  var welcomeSchedule = scheduler.scheduleJob('*/10 * * * *', function() {
+  var welcomeSchedule = scheduler.scheduleJob('* 10 * * * *', function() {
       welcomeUsers()
   });
 


### PR DESCRIPTION
After reading through the documentation for Node Schedule I noticed that they weren't using the escape character in there code examples, just the one markup example.

I believe that this will fix our problem.

What I think was happening was it was taking the ascii value for */10 for the seconds field.  Since it was above 60 it probably just brought it down to the max limit and that's why it was happening every minute instead.
